### PR TITLE
License Addition to the Post Webhook and various styling changes

### DIFF
--- a/Discord Feed Webhook/README.md
+++ b/Discord Feed Webhook/README.md
@@ -1,7 +1,7 @@
 # Discord Feed Webhook
 #### Project Type: Webhook
 #### Author: Costpap
-#### License: Coming Soon
+#### License: [MIT](https://github.com/r-PSNFriends-Mods/scripts/blob/experimental/Discord%20Feed%20Webhook/license.md)
 ## Prerequisites
 - An IFTTT Account
 - A Reddit Account

--- a/Discord Feed Webhook/README.md
+++ b/Discord Feed Webhook/README.md
@@ -1,19 +1,8 @@
 # Discord Feed Webhook
-
-### What is this about?
-This is a service that automatically detects and automatically uploads all your (new) posts in a Subreddit to a Discord Channel, using *IFTTT's webhook service.*
-
-### Can I use this Webhook elsewhere too?
-Sure, no problem. But please note that you'll need the following in order for it to work:
-- An IFTTT & Reddit Account
-- A Discord Webhook
-In addition to that, there are some customized elements, such as colors and icons matching the subreddit. You will need to change those if you intend to have a good looking webhook.
-
-### How do I use this webhook?
-Using this webhook is pretty easy, it's the way you'd use any IFTTT webhook. If you know how to do that, it should be farily easy to get your webhook running.
-
-### Can I contribute to the look of the embed, text, etc?
-Of course, yes. You can contribute to anything. Just be sure to make an [Issue](https://github.com/r-PSNFriends-Mods/user-scripts/issues) or a [Pull Request](https://github.com/r-PSNFriends-Mods/user-scripts/pulls)
-
-### Who is the maintainer of this webhook?
-Moderator [Costpap](https://github.com/Costpap) has access to this webhook. Please direct any questions, Issues/Pull Requests that need to be checked and are long overdue etc. to him.
+#### Project Type: Webhook
+#### Author: Costpap
+#### License: Coming Soon
+## Prerequisites
+- An IFTTT Account
+- A Reddit Account
+- Access to a Discord Webhook

--- a/Discord Feed Webhook/README.md
+++ b/Discord Feed Webhook/README.md
@@ -1,7 +1,7 @@
 # Discord Feed Webhook
 #### Project Type: Webhook
 #### Author: Costpap
-#### License: [MIT](https://github.com/r-PSNFriends-Mods/scripts/blob/experimental/Discord%20Feed%20Webhook/license.md)
+#### License: [MIT](https://github.com/r-PSNFriends-Mods/scripts/blob/master/Discord%20Feed%20Webhook/license.md)
 ## Prerequisites
 - An IFTTT Account
 - A Reddit Account

--- a/Discord Feed Webhook/license.md
+++ b/Discord Feed Webhook/license.md
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2019 Costpap
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # Index
-### Web Hooks
-* [Discord Post Feed](https://github.com/r-PSNFriends-Mods/scripts/tree/master/Discord%20Feed%20Webhook)
+### Webhooks
+* [Discord Feed Webhook](https://github.com/r-PSNFriends-Mods/scripts/tree/master/Discord%20Feed%20Webhook)
 ### User Scripts
 * [OFFCC](https://github.com/r-PSNFriends-Mods/scripts/tree/master/OFFCC)


### PR DESCRIPTION
The Discord Feed Webhook is now licensed under MIT. Also changed the README section of the Webhook to match the new Template, and fixed styling regarding the Webhook in the Index.